### PR TITLE
ci: update recipes once per day

### DIFF
--- a/.github/workflows/deskflow-continuous-update-check.yml
+++ b/.github/workflows/deskflow-continuous-update-check.yml
@@ -8,7 +8,7 @@ name: Update deskflow-dev
 on:
   workflow_dispatch:
   schedule:
-    - cron: "2,22,42 * * * *"
+    - cron: "2 0 * * *"
 
 jobs:
   update-deskflow-dev:

--- a/.github/workflows/deskflow-update-check.yml
+++ b/.github/workflows/deskflow-update-check.yml
@@ -9,7 +9,7 @@ name: Update deskflow
 on:
   workflow_dispatch:
   schedule:
-    - cron: "3,23,43 * * * *"
+    - cron: "3 0 * * *"
 
 jobs:
   update-deskflow:

--- a/README.md
+++ b/README.md
@@ -26,5 +26,4 @@ brew install deskflow-dev
 
 ## Recipe Updates
 
-Recipes are auto updated every 20 minutes
-for this reason users using the `deskflow-dev` install could have frequent updates
+Recipes are auto updated daily


### PR DESCRIPTION
Reduce The Ci runs for the homebrew-tap to running each once per day