### PR TITLE
Fix tap command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A 🍺[Homebrew](https://brew.sh/) tap for [Deskflow](https://github.com/deskflo
 In order to install deskflow you must enable this tap
 
 ```
-brew tap deskflow/homebrew-tap
+brew tap deskflow/tap
 ```
 
 You can then install the following Casks


### PR DESCRIPTION
## Summary

- Fixes the `brew tap` command in README from `deskflow/homebrew-tap` to `deskflow/tap`

Homebrew automatically strips the `homebrew-` prefix from repository names, so the correct command is `brew tap deskflow/tap`.

## Related

- https://github.com/deskflow/deskflow/pull/9246 (same fix for main deskflow README)

## Test plan

- [x] Verify `brew tap deskflow/tap` works correctly