### PR TITLE
ci: only run jobs on dispatch

### DIFF
--- a/.github/workflows/deskflow-continuous-update-check.yml
+++ b/.github/workflows/deskflow-continuous-update-check.yml
@@ -6,9 +6,6 @@
 
 name: Update deskflow-dev
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "2 0 * * *"
   repository_dispatch:
     types: [update_tap]
 

--- a/.github/workflows/deskflow-update-check.yml
+++ b/.github/workflows/deskflow-update-check.yml
@@ -7,9 +7,6 @@
 # Tweak should always be 0 on the new version (not enfored here just ignored)
 name: Update deskflow
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "3 0 * * *"
   repository_dispatch:
     types: [update_tap]
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ brew install deskflow
 ```
 or
 
-The Continuous Build is built daily from the lastest Deskflow commits. Use this if you want try out lastest code
+The continuous build from the lastest Deskflow commits. Use this if you want try out lastest code
 ```
 brew install deskflow-dev
 ```
-
-## Recipe Updates
-
-Recipes are auto updated daily


### PR DESCRIPTION
After https://github.com/deskflow/deskflow/pull/9259

  - Remove cron updates and only run jobs on dispatch from deskflow repo.
  - Update readme to remove the info about auto update 
