### PR TITLE
Update casks to use macos version symbol rather than a string

### DIFF
--- a/Casks/d/deskflow-dev.rb
+++ b/Casks/d/deskflow-dev.rb
@@ -12,7 +12,7 @@ cask "deskflow-dev" do
 
   conflicts_with cask: "deskflow"
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "Deskflow.app"
 

--- a/Casks/d/deskflow.rb
+++ b/Casks/d/deskflow.rb
@@ -12,7 +12,7 @@ cask "deskflow" do
 
   conflicts_with cask: "deskflow-dev"
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "Deskflow.app"
 


### PR DESCRIPTION
This is the new way to set a minimum version dependency (see https://docs.brew.sh/Formula-Cookbook). Without this, there's a deprecation message:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :monterey` instead.
Please report this issue to the deskflow/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/deskflow/homebrew-tap/Casks/d/deskflow.rb:15
```